### PR TITLE
The package org

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3161,7 +3161,7 @@ nvm() {
         esac
         shift
       done
-      if [ -n "${PATTERN-}" ] && [ -n "${NVM_NO_ALIAS}" ]; then
+      if [ -n "${PATTERN-}" ] && [ -n "${NVM_NO_ALIAS-}" ]; then
         nvm_err '`--no-alias` is not supported when a pattern is provided.'
         return 55
       fi

--- a/test/fast/Listing versions/Running "nvm ls" with nounset should not fail.
+++ b/test/fast/Listing versions/Running "nvm ls" with nounset should not fail.
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+\. ../../common.sh
+
+make_fake_node v0.12.34 || die 'fake v0.12.34 could not be made'
+
+# Enable no unset variable
+set -u
+
+# Try an alias that does not exist
+output=$(nvm ls 99 2>&1 1>/dev/null || true)
+test -z "${output}" || die "1: expected empty; got >${output}"
+
+# Try a version that does not exist
+output=$(nvm ls 0.12.00 2>&1 1>/dev/null || true)
+test -z "${output}" || die "2: expected empty; got >${output}"
+
+# Try a version that does exist
+output=$(nvm ls 0.12.34 2>&1 1>/dev/null || true)
+test -z "${output}" || die "3: expected empty; got >${output}"


### PR DESCRIPTION
Adds a default value for NVM_NO_ALIAS so that nvm ls does not error out when run
in a bash nounset/-u (no unset vars) environment.